### PR TITLE
Add epel-release as a CentOS 7 / RHEL 7 requirement

### DIFF
--- a/docs/source/Install.rst
+++ b/docs/source/Install.rst
@@ -254,6 +254,7 @@ Install requirements
 
 ::
 
+	 ~#  yum -y install epel-release
 	 ~#  yum -y install openssh-clients openssl wget gzip tar gawk sed grep coreutils util-linux rpcbind dhcp tftp-server xinetd nfs-utils nfs4-acl-tools mod_ssl qemu-img sqlite redhat-lsb-core bash-completion
 
 

--- a/docs/source/Install.rst
+++ b/docs/source/Install.rst
@@ -254,8 +254,7 @@ Install requirements
 
 ::
 
-	 ~#  yum -y install epel-release
-	 ~#  yum -y install openssh-clients openssl wget gzip tar gawk sed grep coreutils util-linux rpcbind dhcp tftp-server xinetd nfs-utils nfs4-acl-tools mod_ssl qemu-img sqlite redhat-lsb-core bash-completion
+	 ~#  yum -y install openssh-clients openssl wget gzip tar gawk sed grep coreutils util-linux rpcbind dhcp tftp-server xinetd nfs-utils nfs4-acl-tools qemu-img sqlite redhat-lsb-core bash-completion
 
 
 Get DRLM
@@ -265,6 +264,7 @@ Get DRLM
 
 ::
 
+    ~# yum install epel-release
     ~# yum install git rpm-build golang
     ~$ git clone https://github.com/brainupdaters/drlm
     ~$ cd drlm
@@ -390,7 +390,7 @@ Install requirements
 
 ::
 
-	 ~#  yum -y install openssh-clients openssl wget gzip tar gawk sed grep coreutils util-linux rpcbind dhcp tftp-server xinetd nfs-utils nfs4-acl-tools mod_ssl qemu-img sqlite redhat-lsb-core bash-completion
+	 ~#  yum -y install openssh-clients openssl wget gzip tar gawk sed grep coreutils util-linux rpcbind dhcp tftp-server xinetd nfs-utils nfs4-acl-tools qemu-img sqlite redhat-lsb-core bash-completion
 
 
 Get DRLM
@@ -400,6 +400,7 @@ Get DRLM
 
 ::
 
+    ~# yum install epel-release
     ~# yum install git rpm-build golang
     ~$ git clone https://github.com/brainupdaters/drlm
     ~$ cd drlm


### PR DESCRIPTION
The `epel-release` repository is required for installing Golang. This closes fixes #23 